### PR TITLE
Add ESLint configuration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,23 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:astro/recommended',
+  ],
+  overrides: [
+    {
+      files: ['*.astro'],
+      parser: 'astro-eslint-parser',
+      parserOptions: {
+        parser: '@typescript-eslint/parser',
+      },
+    },
+  ],
+};

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,6 +54,9 @@ jobs:
           npm install -g pnpm
           test -d node_modules || pnpm install
 
+      - name: Lint
+        run: pnpm run lint --if-present
+
       - name: Astro check
         run: pnpm run check --if-present
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "astro dev",
     "prettier": "prettier --write .",
     "preview": "astro preview",
-    "start": "astro dev"
+    "start": "astro dev",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint \"src/**/*.{js,ts,jsx,tsx,astro}\" \"infra/**/*.ts\" astro.config.mjs sst.config.ts tailwind.config.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
@@ -62,7 +63,12 @@
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-astro-organize-imports": "^0.4.11",
-    "prettier-plugin-tailwindcss": "^0.6.9"
+    "prettier-plugin-tailwindcss": "^0.6.9",
+    "eslint": "^8.56.0",
+    "eslint-plugin-astro": "^0.31.0",
+    "astro-eslint-parser": "^0.9.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0"
   },
   "prettier": {
     "overrides": [


### PR DESCRIPTION
## Summary
- add ESLint configuration for Astro and TypeScript
- install ESLint-related dependencies
- add lint script
- run lint in PR checks

## Testing
- `pnpm run lint` *(fails: ESLint couldn't find plugin)*
- `pnpm run check --if-present`